### PR TITLE
Fixes #56 - "ready" event not emitted without warmup iterations.

### DIFF
--- a/jetty-load-generator-client/src/main/java/org/mortbay/jetty/load/generator/LoadGenerator.java
+++ b/jetty-load-generator-client/src/main/java/org/mortbay/jetty/load/generator/LoadGenerator.java
@@ -1144,8 +1144,8 @@ public class LoadGenerator extends ContainerLifeCycle {
         public WarmupCallback(Callback callback, int warmupIterations) {
             super(callback);
             latch = new CountDownLatch(warmupIterations == 0 ? 0 : 1);
-            counter = warmupIterations == 0 ? Callback.from(NOOP::succeeded, callback::failed) :
-                    new CountingCallback(Callback.from(this::success, this::failure), warmupIterations);
+            // If there are no warmup iterations, the callback will never be invoked.
+            counter = warmupIterations == 0 ? NOOP : new CountingCallback(Callback.from(this::success, this::failure), warmupIterations);
         }
 
         @Override
@@ -1160,6 +1160,9 @@ public class LoadGenerator extends ContainerLifeCycle {
 
         public void join() {
             try {
+                if (counter == NOOP) {
+                    fireReadyEvent();
+                }
                 latch.await();
             } catch (InterruptedException x) {
                 throw new RuntimeException(x);
@@ -1179,7 +1182,8 @@ public class LoadGenerator extends ContainerLifeCycle {
                     LOGGER.debug("awaiting barrier for ready listener");
                 }
                 awaitBarrier();
-                // Do not succeed the nested callback, as these are just warmup iterations.
+                // Do not forward success the nested callback,
+                // as these are just warmup iterations.
             } finally {
                 latch.countDown();
             }

--- a/jetty-load-generator-client/src/test/java/org/mortbay/jetty/load/generator/LoadGeneratorTest.java
+++ b/jetty-load-generator-client/src/test/java/org/mortbay/jetty/load/generator/LoadGeneratorTest.java
@@ -505,6 +505,27 @@ public class LoadGeneratorTest {
         Assert.assertEquals(threads * count, resources.get());
     }
 
+    @Test
+    public void testReadyEventWithoutWarmup() throws Exception {
+        startServer(new TestHandler());
+
+        int threads = 2;
+        int count = 30;
+        CountDownLatch readyLatch = new CountDownLatch(1);
+        LoadGenerator loadGenerator = LoadGenerator.builder()
+                .port(connector.getLocalPort())
+                .httpClientTransportBuilder(clientTransportBuilder)
+                .threads(threads)
+                .iterationsPerThread(count)
+                .resourceRate(0)
+                .listener((LoadGenerator.ReadyListener)g -> readyLatch.countDown())
+                .build();
+
+        loadGenerator.begin().get();
+
+        Assert.assertTrue(readyLatch.await(5, TimeUnit.SECONDS));
+    }
+
     private enum TransportType {
         H1C, H2C
     }


### PR DESCRIPTION
Now emitting the event when warmupIterations=0.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>