### PR TITLE
Stop the http client instances after firing CompleteEvent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 def oss = ["linux"]
-def jdks = ["jdk11", "jdk17"]
+def jdks = ["jdk11", "jdk17", "jdk21"]
 
 def builds = [:]
 for (def os in oss) {


### PR DESCRIPTION
This allows dumping a `LoadGenerator` instance from within an `onComplete` event listener such that the dump would include the clients themselves.

Also add JDK 21 to the list of JDKs used for Jenkins builds.