### PR TITLE
Add native compilation of jetty-load-starter

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,0 +1,94 @@
+name: Native Binaries
+
+on:
+  push:
+    branches:
+      - main
+      - "4.*.x"
+    tags:
+      - "jetty-load-generator-*"
+  pull_request:
+    branches:
+      - main
+      - "4.*.x"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or PR ref (e.g. refs/pull/42/head)'
+        required: false
+        default: ''
+
+jobs:
+  native:
+    name: Native / ${{ matrix.os-name }}-${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            os-name: linux
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            os-name: linux
+            arch: aarch64
+          - runner: macos-13
+            os-name: macos
+            arch: amd64
+          - runner: macos-latest
+            os-name: macos
+            arch: aarch64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalvm-community'
+          native-image-job-reports: 'true'
+          cache: 'maven'
+
+      - name: Build native binary
+        run: mvn clean install -Pnative -DskipTests -pl jetty-load-generator-starter -am -B -V
+
+      - name: Rename binary
+        run: |
+          mv jetty-load-generator-starter/target/load-generator \
+             load-generator-${{ matrix.os-name }}-${{ matrix.arch }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-generator-${{ matrix.os-name }}-${{ matrix.arch }}
+          path: load-generator-${{ matrix.os-name }}-${{ matrix.arch }}
+          if-no-files-found: error
+
+  release:
+    name: Attach binaries to GitHub Release
+    needs: native
+    if: startsWith(github.ref, 'refs/tags/jetty-load-generator-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all native binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: binaries
+          merge-multiple: false
+
+      - name: Attach binaries to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            binaries/load-generator-linux-amd64/load-generator-linux-amd64
+            binaries/load-generator-linux-aarch64/load-generator-linux-aarch64
+            binaries/load-generator-macos-amd64/load-generator-macos-amd64
+            binaries/load-generator-macos-aarch64/load-generator-macos-aarch64
+          fail_on_unmatched_files: true

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -31,9 +31,6 @@ jobs:
           - runner: ubuntu-24.04-arm
             os-name: linux
             arch: aarch64
-          - runner: macos-13
-            os-name: macos
-            arch: amd64
           - runner: macos-latest
             os-name: macos
             arch: aarch64

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,8 @@ pipeline {
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm
+              sh "id"
+              sh "pwd"
               sh "sdk use java 21.0.2-graalce"
               mavenBuild( "jdk21", "clean install -Pnative", "maven3", true)
               recordCoverage id: "coverage-jdk21", name: "Coverage jdk21", tools: [[parser: 'JACOCO']]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,8 @@ pipeline {
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm
-              mavenBuild( "jdk21", "clean install", "maven3", true)
+              sh "sdk use java 21.0.2-graalce"
+              mavenBuild( "jdk21", "clean install -Pnative", "maven3", true)
               recordCoverage id: "coverage-jdk21", name: "Coverage jdk21", tools: [[parser: 'JACOCO']]
               mavenBuild( "jdk21", "clean javadoc:javadoc -Djacoco.skip=true", "maven3", false)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,12 +17,9 @@ pipeline {
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm
-              sh "id"
-              sh "pwd"
-              sh "sdk use java 21.0.2-graalce"
-              mavenBuild( "jdk21", "clean install -Pnative", "maven3", true)
+              mavenBuild( "GraalVM-21", "clean install -Pnative", "maven3", true)
               recordCoverage id: "coverage-jdk21", name: "Coverage jdk21", tools: [[parser: 'JACOCO']]
-              mavenBuild( "jdk21", "clean javadoc:javadoc -Djacoco.skip=true", "maven3", false)
+              mavenBuild( "GraalVM-21", "clean javadoc:javadoc -Djacoco.skip=true", "maven3", false)
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     stage("Parallel Stage") {
       parallel {
         stage("Build / Test - JDK21") {
-          agent { node { label 'linux-light' } }
+          agent { node { label 'linux' } }
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm

--- a/jetty-load-generator-starter/pom.xml
+++ b/jetty-load-generator-starter/pom.xml
@@ -158,6 +158,7 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>-H:+ReportExceptionStackTraces</buildArg>
+                <buildArg>-march=compatibility</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/jetty-load-generator-starter/pom.xml
+++ b/jetty-load-generator-starter/pom.xml
@@ -54,6 +54,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
@@ -113,5 +119,51 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <!-- GraalVM's built-in Groovy substitutions target Groovy 2.x/3.x APIs removed in Groovy 4+.
+           Override scope to 'provided' so Groovy is absent from the native-image classpath.
+           - resource-groovy-path is unsupported in native mode -->
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>5.0.4</version>
+            <scope>provided</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.10.2</version>
+            <extensions>true</extensions>
+            <executions>
+              <execution>
+                <id>build-native</id>
+                <goals>
+                  <goal>compile-no-fork</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+            <configuration>
+              <imageName>load-generator</imageName>
+              <mainClass>org.mortbay.jetty.load.generator.starter.LoadGeneratorStarter</mainClass>
+              <buildArgs>
+                <buildArg>--no-fallback</buildArg>
+                <buildArg>-H:+ReportExceptionStackTraces</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/reflect-config.json
+++ b/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/reflect-config.json
@@ -1,0 +1,54 @@
+[
+  {
+    "name": "org.mortbay.jetty.load.generator.starter.LoadGeneratorStarterArgs",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.beust.jcommander.Parameter",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.converters.IntegerConverter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.converters.LongConverter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.converters.BooleanConverter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.converters.StringConverter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.validators.NoValidator",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.beust.jcommander.validators.NoValueValidator",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  }
+]

--- a/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/resource-config.json
+++ b/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources": {
+    "includes": [
+      { "pattern": "\\QMETA-INF/services/\\E.*" }
+    ]
+  },
+  "bundles": []
+}


### PR DESCRIPTION
```
mvn clean install -Pnative
```
Then
```
./jetty-load-generator-starter/target/load-generator
```
same parameter as usual except `--resource-groovy-path` as groovy is a bit complicated with native

Log are done with SimpleLogger so system properties are supported such 
```
-Dorg.slf4j.simpleLogger.defaultLogLevel=debug
```

