### PR TITLE
4.1.x native compilation and extra reports

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,0 +1,94 @@
+name: Native Binaries
+
+on:
+  push:
+    branches:
+      - main
+      - "4.*.x"
+    tags:
+      - "jetty-load-generator-*"
+  pull_request:
+    branches:
+      - main
+      - "4.*.x"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or PR ref (e.g. refs/pull/42/head)'
+        required: false
+        default: ''
+
+jobs:
+  native:
+    name: Native / ${{ matrix.os-name }}-${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            os-name: linux
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            os-name: linux
+            arch: aarch64
+          - runner: macos-13
+            os-name: macos
+            arch: amd64
+          - runner: macos-latest
+            os-name: macos
+            arch: aarch64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalvm-community'
+          native-image-job-reports: 'true'
+          cache: 'maven'
+
+      - name: Build native binary
+        run: mvn clean install -Pnative -DskipTests -pl jetty-load-generator-starter -am -B -V
+
+      - name: Rename binary
+        run: |
+          mv jetty-load-generator-starter/target/load-generator \
+             load-generator-${{ matrix.os-name }}-${{ matrix.arch }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-generator-${{ matrix.os-name }}-${{ matrix.arch }}
+          path: load-generator-${{ matrix.os-name }}-${{ matrix.arch }}
+          if-no-files-found: error
+
+  release:
+    name: Attach binaries to GitHub Release
+    needs: native
+    if: startsWith(github.ref, 'refs/tags/jetty-load-generator-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all native binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: binaries
+          merge-multiple: false
+
+      - name: Attach binaries to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            binaries/load-generator-linux-amd64/load-generator-linux-amd64
+            binaries/load-generator-linux-aarch64/load-generator-linux-aarch64
+            binaries/load-generator-macos-amd64/load-generator-macos-amd64
+            binaries/load-generator-macos-aarch64/load-generator-macos-aarch64
+          fail_on_unmatched_files: true

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -31,9 +31,6 @@ jobs:
           - runner: ubuntu-24.04-arm
             os-name: linux
             arch: aarch64
-          - runner: macos-13
-            os-name: macos
-            arch: amd64
           - runner: macos-latest
             os-name: macos
             arch: aarch64

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,8 @@ pipeline {
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm
+              sh "id"
+              sh "pwd"
               sh "sdk use java 21.0.2-graalce"
               mavenBuild( "jdk21", "clean install -Pnative", "maven3", true)
               recordCoverage id: "coverage-jdk21", name: "Coverage jdk21", tools: [[parser: 'JACOCO']]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,8 @@ pipeline {
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm
-              mavenBuild( "jdk21", "clean install", "maven3", true)
+              sh "sdk use java 21.0.2-graalce"
+              mavenBuild( "jdk21", "clean install -Pnative", "maven3", true)
               recordCoverage id: "coverage-jdk21", name: "Coverage jdk21", tools: [[parser: 'JACOCO']]
               mavenBuild( "jdk21", "clean javadoc:javadoc -Djacoco.skip=true", "maven3", false)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,12 +17,9 @@ pipeline {
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm
-              sh "id"
-              sh "pwd"
-              sh "sdk use java 21.0.2-graalce"
-              mavenBuild( "jdk21", "clean install -Pnative", "maven3", true)
+              mavenBuild( "GraalVM-21", "clean install -Pnative", "maven3", true)
               recordCoverage id: "coverage-jdk21", name: "Coverage jdk21", tools: [[parser: 'JACOCO']]
-              mavenBuild( "jdk21", "clean javadoc:javadoc -Djacoco.skip=true", "maven3", false)
+              mavenBuild( "GraalVM-21", "clean javadoc:javadoc -Djacoco.skip=true", "maven3", false)
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     stage("Parallel Stage") {
       parallel {
         stage("Build / Test - JDK21") {
-          agent { node { label 'linux-light' } }
+          agent { node { label 'linux' } }
           steps {
             timeout( time: 180, unit: 'MINUTES' ) {
               checkout scm

--- a/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/LatencyRecorder.java
+++ b/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/LatencyRecorder.java
@@ -1,0 +1,172 @@
+//
+// ========================================================================
+// Copyright (c) 2016-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.mortbay.jetty.load.generator.listeners;
+
+import java.io.Closeable;
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogWriter;
+import org.HdrHistogram.SingleWriterRecorder;
+
+/**
+ * A latency recorder that writes to a file one histogram per second in HdrHistogram's
+ * {@code HistogramLogReader} format.
+ */
+public class LatencyRecorder
+{
+    private final HistogramLogRecorder recorder;
+    private final String histogramFilename;
+
+    /**
+     * Creates a new instance.
+     * @param histogramFilename the histograms file name.
+     * @throws FileNotFoundException if the file cannot be created.
+     */
+    public LatencyRecorder(String histogramFilename) throws FileNotFoundException
+    {
+        this(histogramFilename, 0);
+    }
+    /**
+     * Creates a new instance
+     * @param histogramFilename the histograms file name.
+     * @param minBufferSize the minimum buffer size that is used to collect one histogram, 0 for a default value.
+     * @throws FileNotFoundException if the file cannot be created.
+     */
+    public LatencyRecorder(String histogramFilename, int minBufferSize) throws FileNotFoundException
+    {
+        this.recorder = new HistogramLogRecorder(histogramFilename, 3, 1000, minBufferSize);
+        this.histogramFilename = histogramFilename;
+    }
+
+    /**
+     * @return the histograms file name.
+     */
+    public String getFilename()
+    {
+        return histogramFilename;
+    }
+
+    /**
+     * Starts the recording of the histograms into the file.
+     */
+    public void startRecording()
+    {
+        recorder.startRecording();
+    }
+
+    /**
+     * Stops the recording of the histograms into the file.
+     */
+    public void stopRecording()
+    {
+        recorder.close();
+    }
+
+    /**
+     * Add a latency value to the current histogram.
+     * @param value the latency in ns.
+     */
+    public void recordValue(long value)
+    {
+        recorder.recordValue(value);
+    }
+
+    private static class HistogramLogRecorder implements Closeable
+    {
+        private enum State
+        {
+            NOT_RECORDING, RECORDING, CLOSED
+        }
+
+        private final ThreadLocal<SingleWriterRecorder> recorderTl;
+        private final List<SingleWriterRecorder> recorders = new CopyOnWriteArrayList<>();
+        private final Timer timer = new Timer();
+        private final HistogramLogWriter writer;
+        private volatile HistogramLogRecorder.State state = HistogramLogRecorder.State.NOT_RECORDING;
+
+        public HistogramLogRecorder(String histogramFilename, int numberOfSignificantValueDigits, int intervalInMs, int minBufferSize) throws FileNotFoundException
+        {
+            recorderTl = ThreadLocal.withInitial(() ->
+            {
+                SingleWriterRecorder singleWriterRecorder = new SingleWriterRecorder(numberOfSignificantValueDigits);
+                recorders.add(singleWriterRecorder);
+                return singleWriterRecorder;
+            });
+            writer = new HistogramLogWriter(histogramFilename);
+            timer.schedule(new TimerTask()
+            {
+                private final Histogram collectiveHistogram = new Histogram(numberOfSignificantValueDigits)
+                {
+                    public int getNeededByteBufferCapacity()
+                    {
+                        int superNeededByteBufferCapacity = super.getNeededByteBufferCapacity();
+                        if (minBufferSize > 0)
+                            return Math.max(superNeededByteBufferCapacity, minBufferSize);
+                        else
+                            return superNeededByteBufferCapacity;
+                    }
+                };
+                private Histogram intervalHistogram;
+
+                @Override
+                public void run()
+                {
+                    for (SingleWriterRecorder recorder : recorders)
+                    {
+                        intervalHistogram = recorder.getIntervalHistogram(intervalHistogram, false);
+                        collectiveHistogram.add(intervalHistogram);
+                    }
+                    if (state == HistogramLogRecorder.State.RECORDING)
+                        writer.outputIntervalHistogram(collectiveHistogram);
+                    collectiveHistogram.reset();
+                }
+            }, intervalInMs, intervalInMs);
+        }
+
+        public void startRecording()
+        {
+            if (state != HistogramLogRecorder.State.NOT_RECORDING)
+                throw new IllegalStateException("current state: " + state);
+
+            long now = System.currentTimeMillis();
+            writer.setBaseTime(now);
+            writer.outputBaseTime(now);
+            writer.outputStartTime(now);
+            state = HistogramLogRecorder.State.RECORDING;
+        }
+
+        @Override
+        public void close()
+        {
+            if (state == HistogramLogRecorder.State.CLOSED)
+                return;
+            state = HistogramLogRecorder.State.CLOSED;
+
+            timer.cancel();
+            writer.close();
+        }
+
+        public void recordValue(long value)
+        {
+            // Always record values even if state != State.RECORDING, the timer won't write the
+            // histogram data on disk, but the histogram code will be jit'ed.
+            recorderTl.get().recordValue(value);
+        }
+    }
+}

--- a/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/ResponseStatusReportListener.java
+++ b/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/ResponseStatusReportListener.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -58,7 +57,7 @@ import org.mortbay.jetty.load.generator.Resource;
 public class ResponseStatusReportListener implements Resource.NodeListener, LoadGenerator.CompleteListener
 {
     private final Timer timer = new Timer();
-    private final AtomicReference<ConcurrentMap<String, LongAdder>> statuses = new AtomicReference<>(new ConcurrentHashMap<>());
+    private final AtomicReference<ConcurrentHashMap<String, LongAdder>> statuses = new AtomicReference<>(new ConcurrentHashMap<>());
     private final PrintWriter printWriter;
     private final boolean fullStackTrace;
     private int writeCounter;
@@ -118,7 +117,7 @@ public class ResponseStatusReportListener implements Resource.NodeListener, Load
 
     private void writeStatuses()
     {
-        ConcurrentMap<String, LongAdder> toWrite = statuses.getAndSet(new ConcurrentHashMap<>());
+        ConcurrentHashMap<String, LongAdder> toWrite = statuses.getAndSet(new ConcurrentHashMap<>());
         printWriter.println("[" + (writeCounter++) + "]");
         for (Map.Entry<String, LongAdder> entry : toWrite.entrySet())
         {
@@ -163,21 +162,7 @@ public class ResponseStatusReportListener implements Resource.NodeListener, Load
             key = Integer.toString(status);
         }
 
-        LongAdder longAdder = statuses.get().get(key);
-        if (longAdder == null)
-        {
-            statuses.get().compute(key, (k, v) ->
-            {
-                if (v == null)
-                    v = new LongAdder();
-                v.increment();
-                return v;
-            });
-        }
-        else
-        {
-            longAdder.increment();
-        }
+        statuses.get().computeIfAbsent(key, k -> new LongAdder()).increment();
     }
 
     @Override

--- a/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/ResponseStatusReportListener.java
+++ b/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/ResponseStatusReportListener.java
@@ -1,0 +1,188 @@
+//
+// ========================================================================
+// Copyright (c) 2016-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.mortbay.jetty.load.generator.listeners;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.mortbay.jetty.load.generator.LoadGenerator;
+import org.mortbay.jetty.load.generator.Resource;
+
+/**
+ * <p>A load generator listener that reports information about the status codes.</p>
+ * <p>Usage:</p>
+ * <pre>
+ * // Create the report listener.
+ * ResponseStatusReportListener listener = new ResponseStatusReportListener("http-client-statuses.log");
+ *
+ * // Create the LoadGenerator, passing the listener to relevant builder methods.
+ * LoadGenerator generator = LoadGenerator.builder()
+ *     ...
+ *     .listener(listener)
+ *     .resourceListener(listener)
+ *     .build();
+ *
+ * // Start the load generation.
+ * generator.begin();
+ * </pre>
+ * Until the load generation completes, the {@code http-client-statuses.log} file is written with one report per second that
+ * has the following format:
+ * <pre>
+ * [0]
+ * 5901=200
+ * 98=500
+ * </pre>
+ * where {@code [0]} is the second count since the recording started, {@code 6001=200} is the number of responses with status
+ * code 200 and {@code 98=500} is the number of responses with status code 500.
+ */
+public class ResponseStatusReportListener implements Resource.NodeListener, LoadGenerator.CompleteListener
+{
+    private final Timer timer = new Timer();
+    private final AtomicReference<ConcurrentMap<String, LongAdder>> statuses = new AtomicReference<>(new ConcurrentHashMap<>());
+    private final PrintWriter printWriter;
+    private final boolean fullStackTrace;
+    private int writeCounter;
+    private boolean record;
+
+    public ResponseStatusReportListener(String statusFilename) throws IOException
+    {
+        this(statusFilename, true, 0L);
+    }
+
+    public ResponseStatusReportListener(String statusFilename, long delayBeforeRecordingMs) throws IOException
+    {
+        this(statusFilename, true, delayBeforeRecordingMs);
+    }
+
+    public ResponseStatusReportListener(String statusFilename, boolean fullStackTrace, long delayBeforeRecordingMs) throws IOException
+    {
+        this.printWriter = new PrintWriter(statusFilename, StandardCharsets.UTF_8);
+        this.fullStackTrace = fullStackTrace;
+        if (delayBeforeRecordingMs > 0L)
+        {
+            this.timer.schedule(new TimerTask()
+            {
+                @Override
+                public void run()
+                {
+                    startRecording();
+                }
+            }, delayBeforeRecordingMs);
+        }
+        else
+        {
+            startRecording();
+        }
+    }
+
+    public void startRecording()
+    {
+        this.record = true;
+        this.timer.schedule(new TimerTask()
+        {
+            @Override
+            public void run()
+            {
+                writeStatuses();
+            }
+        }, 1000L, 1000L);
+    }
+
+    public void stopRecording()
+    {
+        record = false;
+        timer.cancel();
+        printWriter.close();
+        writeCounter = 0;
+    }
+
+    private void writeStatuses()
+    {
+        ConcurrentMap<String, LongAdder> toWrite = statuses.getAndSet(new ConcurrentHashMap<>());
+        printWriter.println("[" + (writeCounter++) + "]");
+        for (Map.Entry<String, LongAdder> entry : toWrite.entrySet())
+        {
+            String key = entry.getKey();
+            String value = entry.getValue().toString();
+            printWriter.print(value);
+            printWriter.print('=');
+            printWriter.println(key);
+        }
+        printWriter.println();
+        printWriter.flush();
+    }
+
+    @Override
+    public void onResourceNode(Resource.Info info)
+    {
+        if (!record)
+            return;
+
+        String key;
+
+        Throwable failure = info.getFailure();
+        if (failure != null)
+        {
+            if (fullStackTrace)
+            {
+                StringWriter sw = new StringWriter();
+                try (PrintWriter pw = new PrintWriter(sw))
+                {
+                    failure.printStackTrace(pw);
+                }
+                key = sw.toString();
+            }
+            else
+            {
+                key = failure.getClass().getName();
+            }
+        }
+        else
+        {
+            int status = info.getStatus();
+            key = Integer.toString(status);
+        }
+
+        LongAdder longAdder = statuses.get().get(key);
+        if (longAdder == null)
+        {
+            statuses.get().compute(key, (k, v) ->
+            {
+                if (v == null)
+                    v = new LongAdder();
+                v.increment();
+                return v;
+            });
+        }
+        else
+        {
+            longAdder.increment();
+        }
+    }
+
+    @Override
+    public void onComplete(LoadGenerator loadGenerator)
+    {
+        stopRecording();
+    }
+}

--- a/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/ResponseTimeReportListener.java
+++ b/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/ResponseTimeReportListener.java
@@ -13,21 +13,15 @@
 
 package org.mortbay.jetty.load.generator.listeners;
 
-import java.io.Closeable;
 import java.io.FileNotFoundException;
-import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.HdrHistogram.Histogram;
-import org.HdrHistogram.HistogramLogWriter;
-import org.HdrHistogram.SingleWriterRecorder;
 import org.mortbay.jetty.load.generator.LoadGenerator;
 import org.mortbay.jetty.load.generator.Resource;
 
 /**
- * <p>A load generator listener that reports information about the status codes.</p>
+ * <p>A load generator listener that reports response time histograms.</p>
  * <p>Usage:</p>
  * <pre>
  * // Create the report listener.
@@ -102,120 +96,6 @@ public class ResponseTimeReportListener implements Resource.NodeListener, LoadGe
     public void onComplete(LoadGenerator generator)
     {
         stopRecording();
-    }
-
-    private static class LatencyRecorder
-    {
-        private final HistogramLogRecorder recorder;
-        private final String histogramFilename;
-
-        public LatencyRecorder(String histogramFilename, int minBufferSize) throws FileNotFoundException
-        {
-            this.recorder = new HistogramLogRecorder(histogramFilename, 3, 1000, minBufferSize);
-            this.histogramFilename = histogramFilename;
-        }
-
-        public String getFilename()
-        {
-            return histogramFilename;
-        }
-
-        public void startRecording()
-        {
-            recorder.startRecording();
-        }
-
-        public void stopRecording()
-        {
-            recorder.close();
-        }
-
-        public void recordValue(long value)
-        {
-            recorder.recordValue(value);
-        }
-
-        private static class HistogramLogRecorder implements Closeable
-        {
-            private enum State
-            {
-                NOT_RECORDING, RECORDING, CLOSED
-            }
-
-            private final ThreadLocal<SingleWriterRecorder> recorderTl;
-            private final List<SingleWriterRecorder> recorders = new CopyOnWriteArrayList<>();
-            private final Timer timer = new Timer();
-            private final HistogramLogWriter writer;
-            private volatile HistogramLogRecorder.State state = HistogramLogRecorder.State.NOT_RECORDING;
-
-            public HistogramLogRecorder(String histogramFilename, int numberOfSignificantValueDigits, int intervalInMs, int minBufferSize) throws FileNotFoundException
-            {
-                recorderTl = ThreadLocal.withInitial(() ->
-                {
-                    SingleWriterRecorder singleWriterRecorder = new SingleWriterRecorder(numberOfSignificantValueDigits);
-                    recorders.add(singleWriterRecorder);
-                    return singleWriterRecorder;
-                });
-                writer = new HistogramLogWriter(histogramFilename);
-                timer.schedule(new TimerTask()
-                {
-                    private final Histogram collectiveHistogram = new Histogram(numberOfSignificantValueDigits)
-                    {
-                        public int getNeededByteBufferCapacity()
-                        {
-                            int superNeededByteBufferCapacity = super.getNeededByteBufferCapacity();
-                            if (minBufferSize > 0)
-                                return Math.max(superNeededByteBufferCapacity, minBufferSize);
-                            else
-                                return superNeededByteBufferCapacity;
-                        }
-                    };
-                    private Histogram intervalHistogram;
-                    @Override
-                    public void run()
-                    {
-                        for (SingleWriterRecorder recorder : recorders)
-                        {
-                            intervalHistogram = recorder.getIntervalHistogram(intervalHistogram, false);
-                            collectiveHistogram.add(intervalHistogram);
-                        }
-                        if (state == HistogramLogRecorder.State.RECORDING)
-                            writer.outputIntervalHistogram(collectiveHistogram);
-                        collectiveHistogram.reset();
-                    }
-                }, intervalInMs, intervalInMs);
-            }
-
-            public void startRecording()
-            {
-                if (state != HistogramLogRecorder.State.NOT_RECORDING)
-                    throw new IllegalStateException("current state: " + state);
-
-                long now = System.currentTimeMillis();
-                writer.setBaseTime(now);
-                writer.outputBaseTime(now);
-                writer.outputStartTime(now);
-                state = HistogramLogRecorder.State.RECORDING;
-            }
-
-            @Override
-            public void close()
-            {
-                if (state == HistogramLogRecorder.State.CLOSED)
-                    return;
-                state = HistogramLogRecorder.State.CLOSED;
-
-                timer.cancel();
-                writer.close();
-            }
-
-            public void recordValue(long value)
-            {
-                // Always record values even if state != State.RECORDING, the timer won't write the
-                // histogram data on disk, but the histogram code will be jit'ed.
-                recorderTl.get().recordValue(value);
-            }
-        }
     }
 }
 

--- a/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/ResponseTimeReportListener.java
+++ b/jetty-load-generator-listeners/src/main/java/org/mortbay/jetty/load/generator/listeners/ResponseTimeReportListener.java
@@ -1,0 +1,221 @@
+//
+// ========================================================================
+// Copyright (c) 2016-2022 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.mortbay.jetty.load.generator.listeners;
+
+import java.io.Closeable;
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogWriter;
+import org.HdrHistogram.SingleWriterRecorder;
+import org.mortbay.jetty.load.generator.LoadGenerator;
+import org.mortbay.jetty.load.generator.Resource;
+
+/**
+ * <p>A load generator listener that reports information about the status codes.</p>
+ * <p>Usage:</p>
+ * <pre>
+ * // Create the report listener.
+ * ResponseTimeReportListener listener = new ResponseTimeReportListener("perf.hlog");
+ *
+ * // Create the LoadGenerator, passing the listener to relevant builder methods.
+ * LoadGenerator generator = LoadGenerator.builder()
+ *     ...
+ *     .listener(listener)
+ *     .resourceListener(listener)
+ *     .build();
+ *
+ * // Start the load generation.
+ * generator.begin();
+ * </pre>
+ * Until the load generation completes, the {@code perf.hlog} file is written in HdrHistogram's
+ * {@code HistogramLogReader} format with one histogram per second.
+ */
+public class ResponseTimeReportListener implements Resource.NodeListener, LoadGenerator.CompleteListener
+{
+    private final LatencyRecorder recorder;
+
+    public ResponseTimeReportListener(String histogramFilename) throws FileNotFoundException
+    {
+        this(histogramFilename, 0, 0L);
+    }
+
+    public ResponseTimeReportListener(String histogramFilename, long delayBeforeRecordingMs) throws FileNotFoundException
+    {
+        this(histogramFilename, 0, delayBeforeRecordingMs);
+    }
+
+    public ResponseTimeReportListener(String histogramFilename, int minBufferSize, long delayBeforeRecordingMs) throws FileNotFoundException
+    {
+        this.recorder = new LatencyRecorder(histogramFilename, minBufferSize);
+        if (delayBeforeRecordingMs > 0L)
+        {
+            Timer timer = new Timer(true);
+            timer.schedule(new TimerTask()
+            {
+                @Override
+                public void run()
+                {
+                    startRecording();
+                }
+            }, delayBeforeRecordingMs);
+        }
+        else
+        {
+            startRecording();
+        }
+    }
+
+    public void startRecording()
+    {
+        recorder.startRecording();
+    }
+
+    public void stopRecording()
+    {
+        recorder.stopRecording();
+    }
+
+    @Override
+    public void onResourceNode(Resource.Info info)
+    {
+        long responseTime = info.getResponseTime() - info.getRequestTime();
+        recorder.recordValue(responseTime);
+    }
+
+    @Override
+    public void onComplete(LoadGenerator generator)
+    {
+        stopRecording();
+    }
+
+    private static class LatencyRecorder
+    {
+        private final HistogramLogRecorder recorder;
+        private final String histogramFilename;
+
+        public LatencyRecorder(String histogramFilename, int minBufferSize) throws FileNotFoundException
+        {
+            this.recorder = new HistogramLogRecorder(histogramFilename, 3, 1000, minBufferSize);
+            this.histogramFilename = histogramFilename;
+        }
+
+        public String getFilename()
+        {
+            return histogramFilename;
+        }
+
+        public void startRecording()
+        {
+            recorder.startRecording();
+        }
+
+        public void stopRecording()
+        {
+            recorder.close();
+        }
+
+        public void recordValue(long value)
+        {
+            recorder.recordValue(value);
+        }
+
+        private static class HistogramLogRecorder implements Closeable
+        {
+            private enum State
+            {
+                NOT_RECORDING, RECORDING, CLOSED
+            }
+
+            private final ThreadLocal<SingleWriterRecorder> recorderTl;
+            private final List<SingleWriterRecorder> recorders = new CopyOnWriteArrayList<>();
+            private final Timer timer = new Timer();
+            private final HistogramLogWriter writer;
+            private volatile HistogramLogRecorder.State state = HistogramLogRecorder.State.NOT_RECORDING;
+
+            public HistogramLogRecorder(String histogramFilename, int numberOfSignificantValueDigits, int intervalInMs, int minBufferSize) throws FileNotFoundException
+            {
+                recorderTl = ThreadLocal.withInitial(() ->
+                {
+                    SingleWriterRecorder singleWriterRecorder = new SingleWriterRecorder(numberOfSignificantValueDigits);
+                    recorders.add(singleWriterRecorder);
+                    return singleWriterRecorder;
+                });
+                writer = new HistogramLogWriter(histogramFilename);
+                timer.schedule(new TimerTask()
+                {
+                    private final Histogram collectiveHistogram = new Histogram(numberOfSignificantValueDigits)
+                    {
+                        public int getNeededByteBufferCapacity()
+                        {
+                            int superNeededByteBufferCapacity = super.getNeededByteBufferCapacity();
+                            if (minBufferSize > 0)
+                                return Math.max(superNeededByteBufferCapacity, minBufferSize);
+                            else
+                                return superNeededByteBufferCapacity;
+                        }
+                    };
+                    private Histogram intervalHistogram;
+                    @Override
+                    public void run()
+                    {
+                        for (SingleWriterRecorder recorder : recorders)
+                        {
+                            intervalHistogram = recorder.getIntervalHistogram(intervalHistogram, false);
+                            collectiveHistogram.add(intervalHistogram);
+                        }
+                        if (state == HistogramLogRecorder.State.RECORDING)
+                            writer.outputIntervalHistogram(collectiveHistogram);
+                        collectiveHistogram.reset();
+                    }
+                }, intervalInMs, intervalInMs);
+            }
+
+            public void startRecording()
+            {
+                if (state != HistogramLogRecorder.State.NOT_RECORDING)
+                    throw new IllegalStateException("current state: " + state);
+
+                long now = System.currentTimeMillis();
+                writer.setBaseTime(now);
+                writer.outputBaseTime(now);
+                writer.outputStartTime(now);
+                state = HistogramLogRecorder.State.RECORDING;
+            }
+
+            @Override
+            public void close()
+            {
+                if (state == HistogramLogRecorder.State.CLOSED)
+                    return;
+                state = HistogramLogRecorder.State.CLOSED;
+
+                timer.cancel();
+                writer.close();
+            }
+
+            public void recordValue(long value)
+            {
+                // Always record values even if state != State.RECORDING, the timer won't write the
+                // histogram data on disk, but the histogram code will be jit'ed.
+                recorderTl.get().recordValue(value);
+            }
+        }
+    }
+}
+

--- a/jetty-load-generator-starter/pom.xml
+++ b/jetty-load-generator-starter/pom.xml
@@ -158,6 +158,7 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>-H:+ReportExceptionStackTraces</buildArg>
+                <buildArg>-march=compatibility</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/jetty-load-generator-starter/pom.xml
+++ b/jetty-load-generator-starter/pom.xml
@@ -54,6 +54,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
@@ -113,5 +119,51 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <!-- GraalVM's built-in Groovy substitutions target Groovy 2.x/3.x APIs removed in Groovy 4+.
+           Override scope to 'provided' so Groovy is absent from the native-image classpath.
+           - resource-groovy-path is unsupported in native mode -->
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>5.0.4</version>
+            <scope>provided</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.10.2</version>
+            <extensions>true</extensions>
+            <executions>
+              <execution>
+                <id>build-native</id>
+                <goals>
+                  <goal>compile-no-fork</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+            <configuration>
+              <imageName>load-generator</imageName>
+              <mainClass>org.mortbay.jetty.load.generator.starter.LoadGeneratorStarter</mainClass>
+              <buildArgs>
+                <buildArg>--no-fallback</buildArg>
+                <buildArg>-H:+ReportExceptionStackTraces</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/jetty-load-generator-starter/src/main/java/org/mortbay/jetty/load/generator/starter/LoadGeneratorStarter.java
+++ b/jetty-load-generator-starter/src/main/java/org/mortbay/jetty/load/generator/starter/LoadGeneratorStarter.java
@@ -35,6 +35,8 @@ import org.eclipse.jetty.toolchain.perf.HistogramSnapshot;
 import org.eclipse.jetty.util.ajax.JSON;
 import org.mortbay.jetty.load.generator.LoadGenerator;
 import org.mortbay.jetty.load.generator.listeners.ReportListener;
+import org.mortbay.jetty.load.generator.listeners.ResponseStatusReportListener;
+import org.mortbay.jetty.load.generator.listeners.ResponseTimeReportListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,21 @@ public class LoadGeneratorStarter {
             return;
         }
         LoadGenerator.Builder builder = configure(starterArgs);
+        String responseTimeHistogramsFile = starterArgs.getResponseTimeHistogramsFile();
+        if (responseTimeHistogramsFile != null)
+        {
+            long responseTimeHistogramsDelay = starterArgs.getResponseTimeHistogramsDelay();
+            int responseTimeHistogramsBufferSize = starterArgs.getResponseTimeHistogramsBufferSize();
+            ResponseTimeReportListener responseTimeReportListener = new ResponseTimeReportListener(responseTimeHistogramsFile, responseTimeHistogramsBufferSize, responseTimeHistogramsDelay);
+            builder.listener(responseTimeReportListener).resourceListener(responseTimeReportListener);
+        }
+        String statusesFile = starterArgs.getStatusesFile();
+        if (statusesFile != null)
+        {
+            long statusesRecordingDelay = starterArgs.getStatusesRecordingDelay();
+            ResponseStatusReportListener responseStatusReportListener = new ResponseStatusReportListener(statusesFile, statusesRecordingDelay);
+            builder.listener(responseStatusReportListener).resourceListener(responseStatusReportListener);
+        }
         ReportListener listener = new ReportListener();
         LoadGenerator generator = builder
                 .listener(listener)

--- a/jetty-load-generator-starter/src/main/java/org/mortbay/jetty/load/generator/starter/LoadGeneratorStarterArgs.java
+++ b/jetty-load-generator-starter/src/main/java/org/mortbay/jetty/load/generator/starter/LoadGeneratorStarterArgs.java
@@ -112,7 +112,7 @@ public class LoadGeneratorStarterArgs {
     @Parameter(names = {"--statuses-file", "-stf"}, description = "Statuses output file path")
     private String statusesFile;
 
-    @Parameter(names = {"--statuses-recording-delay", "-srd"}, description = "Statuses recording delay in ms")
+    @Parameter(names = {"--statuses-recording-delay", "-strd"}, description = "Statuses recording delay in ms")
     private long statusesRecordingDelay;
 
     @Parameter(names = {"--rth-file", "-rthf"}, description = "Response time histograms output file path")
@@ -121,7 +121,7 @@ public class LoadGeneratorStarterArgs {
     @Parameter(names = {"--rth-recording-delay", "-rthrd"}, description = "Response time histograms recording delay in ms")
     private long responseTimeHistogramsDelay;
 
-    @Parameter(names = {"--rth-recording-buffer-size", "-rthrbf"}, description = "Response time histograms recording buffer size in bytes")
+    @Parameter(names = {"--rth-recording-buffer-size", "-rthrbs"}, description = "Response time histograms recording buffer size in bytes")
     private int responseTimeHistogramsBufferSize;
 
     @Parameter(names = {"--display-stats", "-ds"}, description = "Whether to display statistics in the terminal")

--- a/jetty-load-generator-starter/src/main/java/org/mortbay/jetty/load/generator/starter/LoadGeneratorStarterArgs.java
+++ b/jetty-load-generator-starter/src/main/java/org/mortbay/jetty/load/generator/starter/LoadGeneratorStarterArgs.java
@@ -109,6 +109,21 @@ public class LoadGeneratorStarterArgs {
     @Parameter(names = {"--stats-file", "-sf"}, description = "Statistics output file path in JSON format")
     private String statsFile;
 
+    @Parameter(names = {"--statuses-file", "-stf"}, description = "Statuses output file path")
+    private String statusesFile;
+
+    @Parameter(names = {"--statuses-recording-delay", "-srd"}, description = "Statuses recording delay in ms")
+    private long statusesRecordingDelay;
+
+    @Parameter(names = {"--rth-file", "-rthf"}, description = "Response time histograms output file path")
+    private String responseTimeHistogramsFile;
+
+    @Parameter(names = {"--rth-recording-delay", "-rthrd"}, description = "Response time histograms recording delay in ms")
+    private long responseTimeHistogramsDelay;
+
+    @Parameter(names = {"--rth-recording-buffer-size", "-rthrbf"}, description = "Response time histograms recording buffer size in bytes")
+    private int responseTimeHistogramsBufferSize;
+
     @Parameter(names = {"--display-stats", "-ds"}, description = "Whether to display statistics in the terminal")
     private boolean displayStats;
 
@@ -329,6 +344,56 @@ public class LoadGeneratorStarterArgs {
 
     public void setStatsFile(String statsFile) {
         this.statsFile = statsFile;
+    }
+
+    public String getStatusesFile()
+    {
+        return statusesFile;
+    }
+
+    public void setStatusesFile(String statusesFile)
+    {
+        this.statusesFile = statusesFile;
+    }
+
+    public long getStatusesRecordingDelay()
+    {
+        return statusesRecordingDelay;
+    }
+
+    public void setStatusesRecordingDelay(long statusesRecordingDelay)
+    {
+        this.statusesRecordingDelay = statusesRecordingDelay;
+    }
+
+    public String getResponseTimeHistogramsFile()
+    {
+        return responseTimeHistogramsFile;
+    }
+
+    public void setResponseTimeHistogramsFile(String responseTimeHistogramsFile)
+    {
+        this.responseTimeHistogramsFile = responseTimeHistogramsFile;
+    }
+
+    public long getResponseTimeHistogramsDelay()
+    {
+        return responseTimeHistogramsDelay;
+    }
+
+    public void setResponseTimeHistogramsDelay(long responseTimeHistogramsDelay)
+    {
+        this.responseTimeHistogramsDelay = responseTimeHistogramsDelay;
+    }
+
+    public int getResponseTimeHistogramsBufferSize()
+    {
+        return responseTimeHistogramsBufferSize;
+    }
+
+    public void setResponseTimeHistogramsBufferSize(int responseTimeHistogramsBufferSize)
+    {
+        this.responseTimeHistogramsBufferSize = responseTimeHistogramsBufferSize;
     }
 
     public boolean isDisplayStats() {

--- a/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/reflect-config.json
+++ b/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/reflect-config.json
@@ -1,5 +1,20 @@
 [
   {
+    "name": "java.util.Base64",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "java.util.Base64$Decoder",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "java.util.Base64$Encoder",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
     "name": "org.mortbay.jetty.load.generator.starter.LoadGeneratorStarterArgs",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,

--- a/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/reflect-config.json
+++ b/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/reflect-config.json
@@ -1,0 +1,54 @@
+[
+  {
+    "name": "org.mortbay.jetty.load.generator.starter.LoadGeneratorStarterArgs",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.beust.jcommander.Parameter",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.converters.IntegerConverter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.converters.LongConverter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.converters.BooleanConverter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.converters.StringConverter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.beust.jcommander.validators.NoValidator",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.beust.jcommander.validators.NoValueValidator",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  }
+]

--- a/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/resource-config.json
+++ b/jetty-load-generator-starter/src/main/resources/META-INF/native-image/org.mortbay.jetty.loadgenerator/jetty-load-generator-starter/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources": {
+    "includes": [
+      { "pattern": "\\QMETA-INF/services/\\E.*" }
+    ]
+  },
+  "bundles": []
+}


### PR DESCRIPTION
Native build of the command line tool + extra report listeners with command-line support and native modifications.

The use-case for such native tool is load-tests probes as they can never get the JIT to compile any code with their naturally low throughput.

Replaces https://github.com/jetty-project/jetty-load-generator/pull/619